### PR TITLE
Fix table creation in DB service

### DIFF
--- a/src/app/database.service.ts
+++ b/src/app/database.service.ts
@@ -61,7 +61,12 @@ export class DatabaseService {
   }
 
   getOrMakeTable(tableName: string): Table {
-    return this.tables.find(t => t.tableName == tableName) || {} as Table;
+    let table = this.tables.find(t => t.tableName == tableName);
+    if (!table) {
+      table = { tableName, columns: [] };
+      this.tables.push(table);
+    }
+    return table;
   }
 
   alterTable(log: LogService, args: alterTableArgs) {

--- a/src/app/gemini-function-declarations.ts
+++ b/src/app/gemini-function-declarations.ts
@@ -61,7 +61,7 @@ const createTableSchema: { [k: string]: FunctionDeclarationSchemaProperty } = {
     columns: columnsSchema,
 };
 
-const aterTableSchema: { [k: string]: FunctionDeclarationSchemaProperty } = {
+const alterTableSchema: { [k: string]: FunctionDeclarationSchemaProperty } = {
     tableName: tableNameSchema,
     addColumns: columnsSchema,
     removeColumns: columnsSchema,
@@ -83,7 +83,7 @@ const alterTableFunctionDeclaration: FunctionDeclaration = {
     parameters: {
         type: FunctionDeclarationSchemaType.OBJECT,
         description: "Alter database table. Modifies column definitions.",
-        properties: aterTableSchema,
+        properties: alterTableSchema,
         required: ["tableName"],
     },
 };


### PR DESCRIPTION
## Summary
- ensure `alterTable` works when table is missing
- fix typo in Gemini function declarations

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684050e5a7208329a3d12162229812d9