### PR TITLE
Add Jasmine test stage to CI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -17,3 +17,16 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: browser-actions/setup-chrome@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test -- --watch=false --browsers=ChromeHeadless


### PR DESCRIPTION
## Summary
- add a `test` job to run Jasmine tests with ChromeHeadless

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6840560a0740832996763ab8b972d169